### PR TITLE
Replaced hardcoded MyGet packages source with `PackageSourceProvider`

### DIFF
--- a/src/SqlServer.Tests/GeneratedVersionsSet.cs
+++ b/src/SqlServer.Tests/GeneratedVersionsSet.cs
@@ -1,26 +1,57 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
 static class GeneratedVersionsSet
 {
+    static readonly SourceCacheContext cache = new() { NoCache = true };
+    static readonly string[] sources;
+
+    static GeneratedVersionsSet()
+    {
+        var settings = Settings.LoadDefaultSettings(Directory.GetCurrentDirectory());
+        var packageSourceProvider = new PackageSourceProvider(settings);
+        var packageSources = packageSourceProvider.LoadPackageSources();
+
+        sources = packageSources
+            .Where(x => x.IsEnabled)
+            .Select(x => x.Source)
+            .ToArray();
+    }
+
     public static IEnumerable<object[]> GetLatestMinors(string packageId, string range)
     {
         var versionRange = VersionRange.Parse(range);
-        using var cache = new SourceCacheContext { NoCache = true };
 
-        string source = "https://www.myget.org/F/particular/api/v3/index.json";
-        var nuget = Repository.Factory.GetCoreV3(source);
-        var resources = nuget.GetResource<FindPackageByIdResource>();
+        HashSet<NuGetVersion> versionSet;
 
-        var versions = resources.GetAllVersionsAsync(packageId, cache, NullLogger.Instance, CancellationToken.None).GetAwaiter().GetResult();
+        try
+        {
+            var versionsFromAllSources = sources.AsParallel().SelectMany(source =>
+            {
+                var nuget = Repository.Factory.GetCoreV3(source);
+                var resources = nuget.GetResource<FindPackageByIdResource>();
+                return resources.GetAllVersionsAsync(packageId, cache, NullLogger.Instance, CancellationToken.None).GetAwaiter().GetResult();
+            });
+            versionSet = new HashSet<NuGetVersion>(versionsFromAllSources);
+        }
+        catch (Exception e)
+        {
+            throw new Exception("Error querying package sources. Review enabled sources and ensure inactive sources are disabled or removed.", e);
+        }
 
         // Get all minors
-        versions = versions.Where(v => (!v.IsPrerelease || v.Release.StartsWith("rc.") || v.Release.StartsWith("beta.") || v.Release.StartsWith("alpha.")) && versionRange.Satisfies(v)).OrderBy(v => v);
+        var versions = versionSet
+            .Where(v => (!v.IsPrerelease || v.Release.StartsWith("rc.") || v.Release.StartsWith("beta.") || v.Release.StartsWith("alpha.")) && versionRange.Satisfies(v))
+            .OrderBy(v => v)
+            .ToArray();
 
         NuGetVersion last = null;
 


### PR DESCRIPTION
Replaced hardcoded MyGet packages source url with dynamic package sources based on repo, user and machine config via `PackageSourceProvider`.