### PR TITLE
Remove update-types: ["version-update:semver-major"] from dependabot config as its behavior is not as expected

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,13 +19,9 @@ updates:
     - dependency-name: "Microsoft.CodeAnalysis.CSharp.Workspaces"
     # Avoids dependabot to create PR's to update wildcard majors as the project files target a specific major of these packages
     - dependency-name: "NServiceBus"
-      update-types: ["version-update:semver-major"]  
     - dependency-name: "NServiceBus.AcceptanceTesting"
-      update-types: ["version-update:semver-major"]
     - dependency-name: "NServiceBus.SqlServer"
-      update-types: ["version-update:semver-major"]
     - dependency-name: "NServiceBus.Transport.SqlServer"
-      update-types: ["version-update:semver-major"]
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
Resolves #49

Remove update-types: ["version-update:semver-major"] from dependabot config as its behavior is not as expected.

Removing this so that these packages are ignored by dependabot. This will require manual updating of these versions.

This is the docs:

> Use to ignore types of updates, such as semver major, minor, or patch updates on version updates (for example: version-update:semver-patch will ignore patch updates). You can combine this with dependency-name: "*" to ignore particular update-types for all dependencies.
Currently, version-update:semver-major, version-update:semver-minor, and version-update:semver-patch are the only supported options.

Source: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore